### PR TITLE
NSString conversion to String

### DIFF
--- a/SwiftColors/SwiftColors.swift
+++ b/SwiftColors/SwiftColors.swift
@@ -109,7 +109,7 @@ public extension SWColor {
     :returns: color with the given hex value and alpha
   */
   public convenience init?(hex: Int, alpha: Float) {
-    var hexString = NSString(format: "%2X", hex)
+    var hexString = NSString(format: "%2X", hex) as! String
     self.init(hexString: hexString as String , alpha: alpha)
   }
 }


### PR DESCRIPTION
NSString and String are no longer toll-free. Explicit casting needed. https://developer.apple.com/swift/blog/?id=23