### PR TITLE
Fixed change in Swift support for 'advance' method, using advancedBy …

### DIFF
--- a/SwiftColors/SwiftColors.swift
+++ b/SwiftColors/SwiftColors.swift
@@ -52,23 +52,23 @@ public extension SWColor {
 
     // Check for hash and remove the hash
     if hex.hasPrefix("#") {
-      hex = hex.substringFromIndex(advance(hex.startIndex, 1))
+        hex = hex.substringFromIndex(hex.startIndex.advancedBy(1))
     }
     
     if (hex.rangeOfString("(^[0-9A-Fa-f]{6}$)|(^[0-9A-Fa-f]{3}$)", options: .RegularExpressionSearch) != nil) {
     
         // Deal with 3 character Hex strings
-        if count(hex) == 3 {
-          let redHex   = hex.substringToIndex(advance(hex.startIndex, 1))
-          let greenHex = hex.substringWithRange(Range<String.Index>(start: advance(hex.startIndex, 1), end: advance(hex.startIndex, 2)))
-          let blueHex  = hex.substringFromIndex(advance(hex.startIndex, 2))
+        if hex.characters.count == 3 {
+          let redHex   = hex.substringToIndex(hex.startIndex.advancedBy(1))
+          let greenHex = hex.substringWithRange(Range<String.Index>(start: hex.startIndex.advancedBy(1), end: hex.startIndex.advancedBy(2)))
+          let blueHex  = hex.substringFromIndex(hex.startIndex.advancedBy(2))
           
           hex = redHex + redHex + greenHex + greenHex + blueHex + blueHex
         }
 
-        let redHex = hex.substringToIndex(advance(hex.startIndex, 2))
-        let greenHex = hex.substringWithRange(Range<String.Index>(start: advance(hex.startIndex, 2), end: advance(hex.startIndex, 4)))
-        let blueHex = hex.substringWithRange(Range<String.Index>(start: advance(hex.startIndex, 4), end: advance(hex.startIndex, 6)))
+        let redHex = hex.substringToIndex(hex.startIndex.advancedBy(2))
+        let greenHex = hex.substringWithRange(Range<String.Index>(start: hex.startIndex.advancedBy(2), end: hex.startIndex.advancedBy(4)))
+        let blueHex = hex.substringWithRange(Range<String.Index>(start: hex.startIndex.advancedBy(4), end: hex.startIndex.advancedBy(6)))
         
         var redInt:   CUnsignedInt = 0
         var greenInt: CUnsignedInt = 0


### PR DESCRIPTION
…instance method instead.

Should solve issue https://github.com/thii/SwiftColors/issues/12