### PR TITLE
Reduce deployment target to iOS 8.0

### DIFF
--- a/SwiftColors.xcodeproj/project.pbxproj
+++ b/SwiftColors.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SwiftColors/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = im.thi.SwiftColors;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -256,6 +257,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SwiftColors/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = im.thi.SwiftColors;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Reduces the iOS deployment target to 8.0. Tested with Xcode 7.1.1 and Swift 2.1.